### PR TITLE
Render plots in parallel with --jobs

### DIFF
--- a/src/histcmp/cli.py
+++ b/src/histcmp/cli.py
@@ -91,11 +91,19 @@ def main(
         )
     ] = ".*",
     format: Annotated[
-        str, 
+        str,
         typer.Option(
             help="Output format for plots (pdf, png, etc.)"
         )
     ] = "pdf",
+    jobs: Annotated[
+        int,
+        typer.Option(
+            "--jobs", "-j",
+            min=1,
+            help="Number of worker processes used to render plots"
+        )
+    ] = 1,
 ):
     try:
         import ROOT
@@ -232,7 +240,7 @@ def main(
         if output is not None:
             if plots is not None:
                 plots.mkdir(exist_ok=True, parents=True)
-            make_report(comparison, output, plots, format=format)
+            make_report(comparison, output, plots, format=format, jobs=jobs)
 
         if status != Status.SUCCESS:
             raise typer.Exit(1)

--- a/src/histcmp/compare.py
+++ b/src/histcmp/compare.py
@@ -5,12 +5,9 @@ from dataclasses import dataclass, field
 import fnmatch
 import re
 
-import rich
 from rich.progress import track
 from rich.text import Text
 from rich.panel import Panel
-from matplotlib import pyplot
-import numpy
 
 from histcmp.console import console, fail, info, good, warn
 from histcmp.root_helpers import (
@@ -19,7 +16,7 @@ from histcmp.root_helpers import (
     convert_hist,
     tefficiency_to_th1,
 )
-from histcmp.plot import plot_ratio, plot_ratio_eff, plot_to_uri
+from histcmp.plot import render_plots
 from histcmp import icons
 import histcmp.checks
 from histcmp.github import is_github_actions, github_actions_marker
@@ -60,6 +57,48 @@ class ComparisonItem:
         return Status.INCONCLUSIVE
         #  raise RuntimeError("Shouldn't happen")
 
+    def plot_specs(self):
+        """
+        Build the picklable plot specifications for this item. This converts
+        the ROOT objects into plain numpy backed histograms, so the result can
+        be shipped to a worker process for rendering with
+        histcmp.plot.render_plots.
+        """
+        specs = []
+
+        if isinstance(self.item_a, ROOT.TH3):
+            h3_a = convert_hist(self.item_a)
+            h3_b = convert_hist(self.item_b)
+
+            for proj in [0, 1, 2]:
+                d = "XYZ"[proj]
+                specs.append(
+                    ("ratio", h3_a.project(proj), h3_b.project(proj), f"_p{d}")
+                )
+
+        elif isinstance(self.item_a, ROOT.TH2):
+            h2_a = convert_hist(self.item_a)
+            h2_b = convert_hist(self.item_b)
+
+            for proj in [0, 1]:
+                d = "XY"[proj]
+                specs.append(
+                    ("ratio", h2_a.project(proj), h2_b.project(proj), f"_p{d}")
+                )
+
+        elif isinstance(self.item_a, ROOT.TEfficiency):
+            a, a_err = convert_hist(self.item_a)
+            b, b_err = convert_hist(self.item_b)
+
+            specs.append(("eff", a, a_err, b, b_err, ""))
+
+        elif isinstance(self.item_a, ROOT.TH1):
+            specs.append(
+                ("ratio", convert_hist(self.item_a), convert_hist(self.item_b), "")
+            )
+
+        return specs
+
     def ensure_plots(
         self,
         report_dir: Path,
@@ -68,75 +107,9 @@ class ComparisonItem:
         label_b: str,
         format: str,
     ):
-        figs = []
-
-        if isinstance(self.item_a, ROOT.TH3):
-            h2_a = convert_hist(self.item_a)
-            h2_b = convert_hist(self.item_b)
-
-            for proj in [0, 1, 2]:
-                h1_a = h2_a.project(proj)
-                h1_b = h2_b.project(proj)
-
-                fig, (ax, rax) = plot_ratio(h1_a, h1_b, label_a, label_b)
-
-                d = "XYZ"[proj]
-
-                figs.append((fig, f"_p{d}"))
-                #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
-
-        elif isinstance(self.item_a, ROOT.TH2):
-            h2_a = convert_hist(self.item_a)
-            h2_b = convert_hist(self.item_b)
-
-            for proj in [0, 1]:
-                h1_a = h2_a.project(proj)
-                h1_b = h2_b.project(proj)
-
-                fig, (ax, rax) = plot_ratio(h1_a, h1_b, label_a, label_b)
-
-                d = "XY"[proj]
-
-                figs.append((fig, f"_p{d}"))
-                #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
-
-        elif isinstance(self.item_a, ROOT.TEfficiency):
-            a, a_err = convert_hist(self.item_a)
-            b, b_err = convert_hist(self.item_b)
-
-            lowest = 0
-            largest = 1.015
-            nonzero = numpy.concatenate(
-                [a.values()[a.values() > 0], b.values()[b.values() > 0]]
-            )
-            if len(nonzero) > 0:
-                lowest = numpy.min(nonzero)
-                largest = numpy.max(nonzero)
-
-            fig, (ax, rax) = plot_ratio_eff(a, a_err, b, b_err, label_a, label_b)
-            figs.append((fig, ""))
-            ax.set_ylim(
-                bottom=lowest * 0.99,
-                top=largest * 1.008,
-            )
-            #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
-
-        elif isinstance(self.item_a, ROOT.TH1):
-            a = convert_hist(self.item_a)
-            b = convert_hist(self.item_b)
-            fig, (ax, rax) = plot_ratio(a, b, label_a, label_b)
-            figs.append((fig, ""))
-
-            #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
-
-        for fig, suffix in figs:
-            try:
-                self._generic_plots.append(plot_to_uri(fig))
-                if plot_dir is not None:
-                    safe_key = self.key.replace("/", "_") + suffix
-                    fig.savefig(plot_dir / f"{safe_key}.{format}")
-            except ValueError as e:
-                rich.print(f"ERROR during plot: {e}")
+        self._generic_plots = render_plots(
+            self.plot_specs(), self.key, label_a, label_b, plot_dir, format
+        )
 
     @property
     def first_plot_index(self):

--- a/src/histcmp/plot.py
+++ b/src/histcmp/plot.py
@@ -8,6 +8,7 @@ import numpy
 import mplhep
 
 import hist
+import rich
 from matplotlib import pyplot
 
 pyplot.rcParams.update(
@@ -183,3 +184,59 @@ def plot_to_uri(figure):
     data = svg_encode(data)
     datauri = f"data:image/svg+xml;utf8,{data}"
     return datauri
+
+
+def init_render_worker():
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+
+
+def render_plots(specs, key, label_a, label_b, plot_dir, format: str):
+    """
+    Render the plot specs produced by ComparisonItem.plot_specs and return the
+    data URIs for embedding in the report.
+
+    This function only handles picklable inputs and does not need ROOT, so it
+    can run in a worker process.
+    """
+    uris = []
+
+    for spec in specs:
+        kind = spec[0]
+
+        if kind == "eff":
+            _, a, a_err, b, b_err, suffix = spec
+
+            lowest = 0
+            largest = 1.015
+            nonzero = numpy.concatenate(
+                [a.values()[a.values() > 0], b.values()[b.values() > 0]]
+            )
+            if len(nonzero) > 0:
+                lowest = numpy.min(nonzero)
+                largest = numpy.max(nonzero)
+
+            fig, (ax, rax) = plot_ratio_eff(a, a_err, b, b_err, label_a, label_b)
+            ax.set_ylim(
+                bottom=lowest * 0.99,
+                top=largest * 1.008,
+            )
+            #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
+        else:
+            _, h_a, h_b, suffix = spec
+
+            fig, (ax, rax) = plot_ratio(h_a, h_b, label_a, label_b)
+            #  mplhep.atlas.text("Simulation Internal", ax=ax, loc=1)
+
+        try:
+            uris.append(plot_to_uri(fig))
+            if plot_dir is not None:
+                safe_key = key.replace("/", "_") + suffix
+                fig.savefig(plot_dir / f"{safe_key}.{format}")
+        except ValueError as e:
+            rich.print(f"ERROR during plot: {e}")
+
+        pyplot.close(fig)
+
+    return uris

--- a/src/histcmp/report.py
+++ b/src/histcmp/report.py
@@ -1,9 +1,10 @@
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 import shutil
 from typing import Union, Optional
 import contextlib
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor
 import re
 from rich.progress import track
 from rich.emoji import Emoji
@@ -167,33 +168,40 @@ def make_report(
                 )
     else:
         # The ROOT objects held by the comparison items cannot be pickled, so
-        # they are converted to plain histograms here before the actual
-        # matplotlib rendering is dispatched to the worker processes.
-        with push_root_level(ROOT.kWarning):
-            specs = [item.plot_specs() for item in comparison.items]
+        # each item is converted to plain histograms just before its rendering
+        # is dispatched to the worker processes. Keeping only a bounded number
+        # of futures outstanding caps memory at O(jobs) in-flight items while
+        # the conversion overlaps with the rendering in the workers.
+        queue = deque()
+
+        def drain(limit: int):
+            while len(queue) > limit:
+                future, item = queue.popleft()
+                item._generic_plots = future.result()
 
         with ProcessPoolExecutor(
             max_workers=jobs, initializer=init_render_worker
         ) as executor:
-            futures = {
-                executor.submit(
-                    render_plots,
-                    spec,
-                    item.key,
-                    comparison.label_monitored,
-                    comparison.label_reference,
-                    plot_dir,
-                    format,
-                ): item
-                for item, spec in zip(comparison.items, specs)
-            }
-            for future in track(
-                as_completed(futures),
-                total=len(futures),
-                description="Making plots",
-                console=console,
-            ):
-                futures[future]._generic_plots = future.result()
+            with push_root_level(ROOT.kWarning):
+                for item in track(
+                    comparison.items, description="Making plots", console=console
+                ):
+                    queue.append(
+                        (
+                            executor.submit(
+                                render_plots,
+                                item.plot_specs(),
+                                item.key,
+                                comparison.label_monitored,
+                                comparison.label_reference,
+                                plot_dir,
+                                format,
+                            ),
+                            item,
+                        )
+                    )
+                    drain(4 * jobs)
+            drain(0)
 
     with output.open("w") as fh:
         fh.write(env.get_template("main.html.j2").render(comparison=comparison))

--- a/src/histcmp/report.py
+++ b/src/histcmp/report.py
@@ -13,6 +13,7 @@ import jinja2
 from histcmp.compare import Comparison
 from histcmp.checks import Status
 from histcmp.console import console
+from histcmp.plot import init_render_worker, render_plots
 from histcmp.root_helpers import push_root_level
 from histcmp import icons
 
@@ -143,6 +144,7 @@ def make_report(
     output: Path,
     plot_dir: Optional[Path] = None,
     format: str = "pdf",
+    jobs: int = 1,
 ):
 
     #  copy_static(output)
@@ -151,19 +153,47 @@ def make_report(
 
     import ROOT
 
-    with push_root_level(ROOT.kWarning):
-        for item in track(
-            comparison.items, description="Making plots", console=console
-        ):
-            p = item.ensure_plots(
-                output,
-                plot_dir,
-                comparison.label_monitored,
-                comparison.label_reference,
-                format=format,
-            )
-            if p is not None:
-                console.print(p)
+    if jobs == 1:
+        with push_root_level(ROOT.kWarning):
+            for item in track(
+                comparison.items, description="Making plots", console=console
+            ):
+                item.ensure_plots(
+                    output,
+                    plot_dir,
+                    comparison.label_monitored,
+                    comparison.label_reference,
+                    format=format,
+                )
+    else:
+        # The ROOT objects held by the comparison items cannot be pickled, so
+        # they are converted to plain histograms here before the actual
+        # matplotlib rendering is dispatched to the worker processes.
+        with push_root_level(ROOT.kWarning):
+            specs = [item.plot_specs() for item in comparison.items]
+
+        with ProcessPoolExecutor(
+            max_workers=jobs, initializer=init_render_worker
+        ) as executor:
+            futures = {
+                executor.submit(
+                    render_plots,
+                    spec,
+                    item.key,
+                    comparison.label_monitored,
+                    comparison.label_reference,
+                    plot_dir,
+                    format,
+                ): item
+                for item, spec in zip(comparison.items, specs)
+            }
+            for future in track(
+                as_completed(futures),
+                total=len(futures),
+                description="Making plots",
+                console=console,
+            ):
+                futures[future]._generic_plots = future.result()
 
     with output.open("w") as fh:
         fh.write(env.get_template("main.html.j2").render(comparison=comparison))


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

In the ACTS physmon CI, histcmp invocations on track fitting performance files take ~110 s each, and profiling shows ~75% of that is matplotlib figure rendering (394 figures for a file with 236 histograms, at ~200 ms fixed per-figure overhead). The rendering parallelizes well across processes.

### Changes

- `ComparisonItem.plot_specs()` builds picklable plot specifications (plain numpy-backed `hist` objects, converted from ROOT in the main process, since ROOT objects can't be pickled).
- The matplotlib rendering moves to `histcmp.plot.render_plots()`, which doesn't import ROOT and can run in a `ProcessPoolExecutor` worker (`plot.py` has no ROOT dependency, so spawn-based workers stay lightweight).
- New `--jobs/-j` CLI option (default 1 = unchanged serial path; both paths share the same rendering code).
- Items are converted and submitted lazily with a bounded number of outstanding futures (4×jobs), so the ROOT→numpy conversion in the main process overlaps with the rendering in the workers and in-flight converted items are capped at O(jobs) instead of O(items).
- Figures are closed after rendering, bounding memory that previously grew with every open pyplot figure.

### Test

On a physmon `performance_trackfitting.root` compared against itself (394 figures): `-j 1` 75 s → `-j 4` ~41 s (the residual ~30 s is serial ROOT checks and I/O plus report templating). Reports and PDF plot outputs are identical apart from matplotlib's per-process SVG hash salts and embedded timestamps, which already differ between any two runs. `tests/` unchanged: 1 passed, 1 pre-existing failure (`test_comparison_ckf_main`, typer/click exit-code handling) that fails identically on `main`.

See #10 for an alternative that parallelizes the whole per-item pipeline (checks included) instead of only the rendering.