### PR TITLE
Add --no-projections option to skip projection items

### DIFF
--- a/src/histcmp/cli.py
+++ b/src/histcmp/cli.py
@@ -91,11 +91,20 @@ def main(
         )
     ] = ".*",
     format: Annotated[
-        str, 
+        str,
         typer.Option(
             help="Output format for plots (pdf, png, etc.)"
         )
     ] = "pdf",
+    projections: Annotated[
+        bool,
+        typer.Option(
+            "--projections/--no-projections",
+            help="Compare projection items (TH2 / TH3 / TProfile2D / TProfile3D, "
+            "compared via their 1D projections). Disabling this skips these items "
+            "entirely, which can speed up the comparison considerably"
+        )
+    ] = True,
 ):
     try:
         import ROOT
@@ -138,7 +147,9 @@ def main(
                 filters = fh.read().strip().split("\n")
         else:
             filters = [_filter]
-        comparison = compare(config, monitored, reference, filters=filters)
+        comparison = compare(
+            config, monitored, reference, filters=filters, projections=projections
+        )
 
         comparison.label_monitored = label_monitored
         comparison.label_reference = label_reference

--- a/src/histcmp/compare.py
+++ b/src/histcmp/compare.py
@@ -174,6 +174,18 @@ def can_handle_item(item) -> bool:
     return False
 
 
+def is_projection_item(item) -> bool:
+    """
+    Items that are not compared directly but through their 1D projections.
+    TProfile2D / TProfile3D inherit from TH2 / TH3 and are listed explicitly
+    for clarity. Plain TProfile is one-dimensional and compared directly, so
+    it is not included.
+    """
+    return isinstance(
+        item, (ROOT.TH2, ROOT.TH3, ROOT.TProfile2D, ROOT.TProfile3D)
+    )
+
+
 def collect_items(d, prefix=None):
     items = {}
     dname = d.GetName()
@@ -207,7 +219,13 @@ def collect_items(d, prefix=None):
     return items
 
 
-def compare(config: Config, a: Path, b: Path, filters: List[str]) -> Comparison:
+def compare(
+    config: Config,
+    a: Path,
+    b: Path,
+    filters: List[str],
+    projections: bool = True,
+) -> Comparison:
     rf_a = ROOT.TFile.Open(str(a))
     rf_b = ROOT.TFile.Open(str(b))
 
@@ -262,6 +280,10 @@ def compare(config: Config, a: Path, b: Path, filters: List[str]) -> Comparison:
             result.a_only.add(key)
 
         console.rule(f"{key} ({item_a.__class__.__name__})")
+
+        if not projections and is_projection_item(item_a):
+            info(f"Skipping projection item {key}")
+            continue
 
         if not can_handle_item(item_a):
             warn(f"Unable to handle item of type {type(item_a)}")


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

TH2/TH3 histograms are compared through checks and plots of each 1D projection. On files with many such items this dominates histcmp's runtime — in the ACTS physmon CI, a track fitting performance file (96 TH2 + 32 TH3) takes ~75 s, of which ~60 s goes into the projection items.

### Changes

- New `--projections/--no-projections` CLI option, default enabled (unchanged behavior).
- With `--no-projections`, items matching `is_projection_item` (TH2, TH3, TProfile2D, TProfile3D) are skipped with an info message and don't appear in the report, consistent with how other unhandled item types are treated.
- Plain `TProfile` items are one-dimensional and compared directly, so they are always kept regardless of this option.

### Test

On the physmon `performance_trackfitting.root` compared against itself: 75 s → 14 s, 128 projection items skipped, the remaining 106 items (incl. 10 TProfile) checked as before, report size 28 MB → 7.5 MB. Default invocation is byte-for-byte the previous code path. `tests/`: 1 passed, 1 pre-existing failure that fails identically on `main`.

Complements #7 — the two options address the same physmon bottleneck independently (skip vs parallelize).