### PR TITLE
Create output directories in make_report

### DIFF
--- a/src/histcmp/cli.py
+++ b/src/histcmp/cli.py
@@ -238,8 +238,6 @@ def main(
         )
 
         if output is not None:
-            if plots is not None:
-                plots.mkdir(exist_ok=True, parents=True)
             make_report(comparison, output, plots, format=format, jobs=jobs)
 
         if status != Status.SUCCESS:

--- a/src/histcmp/report.py
+++ b/src/histcmp/report.py
@@ -147,6 +147,9 @@ def make_report(
     format: str = "pdf",
     jobs: int = 1,
 ):
+    output.parent.mkdir(exist_ok=True, parents=True)
+    if plot_dir is not None:
+        plot_dir.mkdir(exist_ok=True, parents=True)
 
     #  copy_static(output)
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Running with `-o` but without `-p` crashes with `FileNotFoundError` when the report is written at the very end of the run, because the report's parent directory was previously only created as a side effect of the plot-directory creation in the CLI.

`make_report` now creates both the report parent directory and the plot directory itself — it is the code that writes into them, so the CLI loses its mkdir logic entirely.

Context: in the ACTS physmon CI we want to be able to drop the per-figure PDF files (~3800 per run, roughly half the figure-saving cost) by simply omitting `-p`; this fix makes that possible. An earlier version of this PR also added a `--no-plot-files` option, but that was redundant with omitting `-p`.

### Test

On a physmon reference file compared against itself: without `-p` the report is written into a previously non-existent directory (exit 0); with `-p` behavior is unchanged (20 PDFs for 20 histograms). `tests/`: 1 passed, 1 pre-existing failure that fails identically on `main`.