### PR TITLE
Compare and plot items in parallel worker processes with --jobs

### DIFF
--- a/src/histcmp/checks.py
+++ b/src/histcmp/checks.py
@@ -2,6 +2,7 @@ import numpy
 import operator
 from abc import ABC, abstractmethod, abstractproperty
 import collections
+import dataclasses
 from pathlib import Path
 import ctypes
 import functools
@@ -102,6 +103,40 @@ class CompatCheck(ABC):
     @abstractproperty
     def name(self) -> str:
         raise NotImplementedError()
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __reduce__(self):
+        # Checks hold ROOT histograms, which cannot be pickled. Crossing a
+        # process boundary therefore turns a check into its CheckSummary,
+        # which exposes the same attributes the console output, the report
+        # template and the status aggregation use. bool() matches the
+        # truthiness semantics of the serial path (ResidualCheck.is_applicable
+        # is a method, not a property, and is truthy wherever it is consumed).
+        applicable = bool(self.is_applicable)
+        return (
+            CheckSummary,
+            (
+                str(self),
+                self.status,
+                applicable,
+                bool(self.is_valid) if applicable else False,
+                bool(self.is_disabled),
+                self.label if applicable else "",
+            ),
+        )
+
+
+@dataclasses.dataclass
+class CheckSummary:
+    name: str
+    status: Status
+    is_applicable: bool
+    is_valid: bool
+    is_disabled: bool
+    label: str
+    plot: Optional[Path] = None
 
     def __str__(self) -> str:
         return self.name

--- a/src/histcmp/cli.py
+++ b/src/histcmp/cli.py
@@ -101,7 +101,7 @@ def main(
         typer.Option(
             "--jobs", "-j",
             min=1,
-            help="Number of worker processes used to render plots"
+            help="Number of worker processes used to compare items and render plots"
         )
     ] = 1,
     renderer_3d: Annotated[
@@ -192,6 +192,13 @@ def main(
                 filters = fh.read().strip().split("\n")
         else:
             filters = [_filter]
+        # Without an output there is nothing to plot, so the parallel
+        # per-item pipeline (which also renders) is not worth spinning up.
+        if output is None:
+            jobs = 1
+        if jobs > 1 and plots is not None:
+            plots.mkdir(exist_ok=True, parents=True)
+
         comparison = compare(
             config,
             monitored,
@@ -199,6 +206,11 @@ def main(
             filters=filters,
             enable_2d=enable_2d,
             enable_3d=enable_3d,
+            jobs=jobs,
+            label_monitored=label_monitored,
+            label_reference=label_reference,
+            plot_dir=plots,
+            format=format,
         )
 
         comparison.label_monitored = label_monitored
@@ -291,7 +303,7 @@ def main(
         )
 
         if output is not None:
-            make_report(comparison, output, plots, format=format, jobs=jobs)
+            make_report(comparison, output, plots, format=format)
 
         if status != Status.SUCCESS:
             raise typer.Exit(1)

--- a/src/histcmp/compare.py
+++ b/src/histcmp/compare.py
@@ -60,52 +60,7 @@ class ComparisonItem:
         #  raise RuntimeError("Shouldn't happen")
 
     def plot_specs(self):
-        """
-        Build the picklable plot specifications for this item. This converts
-        the ROOT objects into plain numpy backed histograms, so the result can
-        be shipped to a worker process for rendering with
-        histcmp.plot.render_plots.
-        """
-        specs = []
-
-        if isinstance(self.item_a, ROOT.TH3):
-            specs.append(
-                PlotSpec(
-                    "3d",
-                    convert_hist(self.item_a),
-                    convert_hist(self.item_b),
-                    renderer=self.plots.renderer_3d,
-                    comparison=self.plots.effective_comparison_2d3d,
-                )
-            )
-
-        elif isinstance(self.item_a, ROOT.TH2):
-            specs.append(
-                PlotSpec(
-                    "2d",
-                    convert_hist(self.item_a),
-                    convert_hist(self.item_b),
-                    comparison=self.plots.effective_comparison_2d3d,
-                )
-            )
-
-        elif isinstance(self.item_a, ROOT.TEfficiency):
-            a, a_err = convert_hist(self.item_a)
-            b, b_err = convert_hist(self.item_b)
-
-            specs.append(PlotSpec("eff", a, b, err_a=a_err, err_b=b_err))
-
-        elif isinstance(self.item_a, ROOT.TH1):
-            specs.append(
-                PlotSpec(
-                    "1d",
-                    convert_hist(self.item_a),
-                    convert_hist(self.item_b),
-                    comparison=self.plots.comparison,
-                )
-            )
-
-        return specs
+        return build_plot_specs(self.item_a, self.item_b, self.plots)
 
     def ensure_plots(
         self,
@@ -115,6 +70,9 @@ class ComparisonItem:
         label_b: str,
         format: str,
     ):
+        if self._generic_plots:
+            # already rendered, e.g. by a worker process during compare()
+            return
         self._generic_plots = render_plots(
             self.plot_specs(), self.key, label_a, label_b, plot_dir, format
         )
@@ -155,37 +113,161 @@ def can_handle_item(item) -> bool:
     return False
 
 
-def collect_items(d, prefix=None):
+def build_plot_specs(item_a, item_b, plots: PlotConfig):
+    """
+    Build the picklable plot specifications for an item. This converts the
+    ROOT objects into plain numpy backed histograms, so the result can be
+    shipped across process boundaries and rendered with
+    histcmp.plot.render_plots.
+    """
+    specs = []
+
+    if isinstance(item_a, ROOT.TH3):
+        specs.append(
+            PlotSpec(
+                "3d",
+                convert_hist(item_a),
+                convert_hist(item_b),
+                renderer=plots.renderer_3d,
+                comparison=plots.effective_comparison_2d3d,
+            )
+        )
+
+    elif isinstance(item_a, ROOT.TH2):
+        specs.append(
+            PlotSpec(
+                "2d",
+                convert_hist(item_a),
+                convert_hist(item_b),
+                comparison=plots.effective_comparison_2d3d,
+            )
+        )
+
+    elif isinstance(item_a, ROOT.TEfficiency):
+        a, a_err = convert_hist(item_a)
+        b, b_err = convert_hist(item_b)
+
+        specs.append(PlotSpec("eff", a, b, err_a=a_err, err_b=b_err))
+
+    elif isinstance(item_a, ROOT.TH1):
+        specs.append(
+            PlotSpec(
+                "1d",
+                convert_hist(item_a),
+                convert_hist(item_b),
+                comparison=plots.comparison,
+            )
+        )
+
+    return specs
+
+
+def collect_items(d, prefix=None, lazy=False, dirpath=""):
+    """
+    Collect the histogram-like objects of a file, keyed by flattened name.
+
+    With lazy=True nothing but directories is read from the file: the values
+    are (classname, path-within-file) tuples instead of the objects, so
+    worker processes can read the objects themselves via TFile.Get(path).
+    """
     items = {}
     dname = d.GetName()
     if isinstance(d, ROOT.TFile):
         dname = ""
     for k in d.GetListOfKeys():
-        obj = k.ReadObj()
-        #  print(type(obj))
-        if isinstance(obj, ROOT.TDirectoryFile):
+        tclass = ROOT.TClass.GetClass(k.GetClassName())
+        if tclass is None:
+            continue
+        if tclass.InheritsFrom("TDirectoryFile"):
             items.update(
                 collect_items(
-                    obj,
+                    k.ReadObj(),
                     prefix + dname + k.GetName() + "__" if prefix is not None else "",
+                    lazy=lazy,
+                    dirpath=dirpath + k.GetName() + "/",
                 )
             )
             continue
-        if (
-            not isinstance(obj, ROOT.TH1)
-            and not isinstance(obj, ROOT.TH3)
-            and not isinstance(obj, ROOT.TH2)
-            and not isinstance(obj, ROOT.TEfficiency)
-        ):
+        if not tclass.InheritsFrom("TH1") and not tclass.InheritsFrom("TEfficiency"):
             continue
-        obj.SetDirectory(0)
         p = prefix or ""
         #  print(prefix)
         ik = (
             p + dname + "__" + k.GetName() if (dname != "" and p != "") else k.GetName()
         )
-        items[ik] = obj
+        if lazy:
+            items[ik] = (k.GetClassName(), dirpath + k.GetName())
+        else:
+            obj = k.ReadObj()
+            obj.SetDirectory(0)
+            items[ik] = obj
     return items
+
+
+def build_checks(config_checks: dict, key: str, item_a, item_b) -> List[CompatCheck]:
+    configured_checks = {}
+    for pattern, checks in config_checks.items():
+        if not fnmatch.fnmatch(key, pattern):
+            continue
+
+        #  print(key, pattern, "matches")
+
+        for cname, check_kw in checks.items():
+            ctype = getattr(histcmp.checks, cname)
+            if ctype not in configured_checks:
+                if check_kw is not None:
+                    configured_checks[ctype] = check_kw.copy()
+            else:
+                #  print("Modifying", cname)
+                if check_kw is None:
+                    #  print("-> setting disabled")
+                    configured_checks[ctype].update({"disabled": True})
+                else:
+                    #  print("-> updating kw")
+                    configured_checks[ctype].update(check_kw)
+
+    #  print(configured_checks)
+
+    return [
+        ctype(item_a, item_b, **check_kw)
+        for ctype, check_kw in configured_checks.items()
+    ]
+
+
+def report_item_console(key: str, checks):
+    dstyle = "strike"
+    for inst in checks:
+        if inst.is_applicable:
+            if inst.is_valid:
+                console.print(
+                    icons.success,
+                    Text(
+                        str(inst),
+                        style="bold green" if not inst.is_disabled else dstyle,
+                    ),
+                    inst.label,
+                )
+            else:
+                if is_github_actions and not inst.is_disabled:
+                    print(
+                        github_actions_marker(
+                            "error",
+                            key + ": " + str(inst) + "\n" + inst.label,
+                        )
+                    )
+                console.print(
+                    icons.failure,
+                    Text(
+                        str(inst),
+                        style="bold red" if not inst.is_disabled else dstyle,
+                    ),
+                    inst.label,
+                )
+        else:
+            console.print(icons.inconclusive, inst, style="yellow")
+
+    if all(c.status == Status.INCONCLUSIVE for c in checks):
+        print(github_actions_marker("warning", key + ": has no applicable checks"))
 
 
 def compare(
@@ -195,12 +277,17 @@ def compare(
     filters: List[str],
     enable_2d: bool = True,
     enable_3d: bool = True,
+    jobs: int = 1,
+    label_monitored: Optional[str] = None,
+    label_reference: Optional[str] = None,
+    plot_dir: Optional[Path] = None,
+    format: str = "pdf",
 ) -> Comparison:
     rf_a = ROOT.TFile.Open(str(a))
     rf_b = ROOT.TFile.Open(str(b))
 
-    key_map_a = collect_items(rf_a)
-    key_map_b = collect_items(rf_b)
+    key_map_a = collect_items(rf_a, lazy=jobs > 1)
+    key_map_b = collect_items(rf_b, lazy=jobs > 1)
 
     keys_a = set(key_map_a.keys())
     keys_b = set(key_map_b.keys())
@@ -234,6 +321,27 @@ def compare(
 
     result = Comparison(file_a=str(a), file_b=str(b))
 
+    if jobs > 1:
+        _compare_parallel(
+            result,
+            config,
+            common,
+            key_map_a,
+            key_map_b,
+            enable_2d,
+            enable_3d,
+            jobs,
+            label_monitored,
+            label_reference,
+            plot_dir,
+            format,
+        )
+        result.b_only = {(k, key_map_b[k][0]) for k in (keys_b - keys_a)}
+        result.a_only = {(k, key_map_a[k][0]) for k in (keys_a - keys_b)}
+        result.common = {(k, key_map_a[k][0]) for k in common}
+
+        return result
+
     for key in track(sorted(common), console=console, description="Comparing..."):
         item_a = key_map_a[key]
         item_b = key_map_b[key]
@@ -266,72 +374,102 @@ def compare(
         item = ComparisonItem(
             key=key, item_a=item_a, item_b=item_b, plots=config.plots
         )
-
-        configured_checks = {}
-        for pattern, checks in config.checks.items():
-            if not fnmatch.fnmatch(key, pattern):
-                continue
-
-            #  print(key, pattern, "matches")
-
-            for cname, check_kw in checks.items():
-                ctype = getattr(histcmp.checks, cname)
-                if ctype not in configured_checks:
-                    if check_kw is not None:
-                        configured_checks[ctype] = check_kw.copy()
-                else:
-                    #  print("Modifying", cname)
-                    if check_kw is None:
-                        #  print("-> setting disabled")
-                        configured_checks[ctype].update({"disabled": True})
-                    else:
-                        #  print("-> updating kw")
-                        configured_checks[ctype].update(check_kw)
-
-        #  print(configured_checks)
-
-        dstyle = "strike"
-        for ctype, check_kw in configured_checks.items():
-            #  print(ctype, check_kw)
-            inst = ctype(item_a, item_b, **check_kw)
-
-            item.checks.append(inst)
-            if inst.is_applicable:
-                if inst.is_valid:
-                    console.print(
-                        icons.success,
-                        Text(
-                            str(inst),
-                            style="bold green" if not inst.is_disabled else dstyle,
-                        ),
-                        inst.label,
-                    )
-                else:
-                    if is_github_actions and not inst.is_disabled:
-                        print(
-                            github_actions_marker(
-                                "error",
-                                key + ": " + str(inst) + "\n" + inst.label,
-                            )
-                        )
-                    console.print(
-                        icons.failure,
-                        Text(
-                            str(inst),
-                            style="bold red" if not inst.is_disabled else dstyle,
-                        ),
-                        inst.label,
-                    )
-            else:
-                console.print(icons.inconclusive, inst, style="yellow")
+        item.checks = build_checks(config.checks, key, item_a, item_b)
+        report_item_console(key, item.checks)
 
         result.items.append(item)
-
-        if all(c.status == Status.INCONCLUSIVE for c in item.checks):
-            print(github_actions_marker("warning", key + ": has no applicable checks"))
 
     result.b_only = {(k, rf_b.Get(k).__class__.__name__) for k in (keys_b - keys_a)}
     result.a_only = {(k, rf_a.Get(k).__class__.__name__) for k in (keys_a - keys_b)}
     result.common = {(k, rf_a.Get(k).__class__.__name__) for k in common}
 
     return result
+
+
+def _compare_parallel(
+    result: Comparison,
+    config: Config,
+    common: set,
+    key_map_a: dict,
+    key_map_b: dict,
+    enable_2d: bool,
+    enable_3d: bool,
+    jobs: int,
+    label_monitored: Optional[str],
+    label_reference: Optional[str],
+    plot_dir: Optional[Path],
+    format: str,
+):
+    """
+    Compare the common items by scheduling them by name onto worker processes
+    which read the objects from the files themselves, run the checks and
+    render the plots (see histcmp.worker). The main process only prints the
+    results and assembles the comparison items from the returned summaries.
+    """
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+
+    from histcmp.worker import init_worker, process_item
+
+    with ProcessPoolExecutor(
+        max_workers=jobs,
+        initializer=init_worker,
+        initargs=(
+            result.file_a,
+            result.file_b,
+            config,
+            label_monitored,
+            label_reference,
+            plot_dir,
+            format,
+        ),
+    ) as executor:
+        futures = {}
+        for key in sorted(common):
+            cls_a, path_a = key_map_a[key]
+            cls_b, path_b = key_map_b[key]
+
+            if cls_a != cls_b:
+                console.rule(f"{key}")
+                fail(
+                    f"Type mismatch between files for key {key}: {cls_a} != {cls_b} => treating as both removed and newly added"
+                )
+                result.a_only.add(key)
+
+            tclass = ROOT.TClass.GetClass(cls_a)
+            # note: TH3 does not inherit from TH2, so the order doesn't matter
+            if not enable_3d and tclass.InheritsFrom("TH3"):
+                console.rule(f"{key} ({cls_a})")
+                info(f"Skipping 3D item {key}")
+                continue
+            if not enable_2d and tclass.InheritsFrom("TH2"):
+                console.rule(f"{key} ({cls_a})")
+                info(f"Skipping 2D item {key}")
+                continue
+
+            futures[executor.submit(process_item, key, path_a, path_b)] = key
+
+        results = {}
+        for future in track(
+            as_completed(futures),
+            total=len(futures),
+            description="Comparing...",
+            console=console,
+        ):
+            results[futures[future]] = future.result()
+
+    for key in sorted(results):
+        cls_a, _ = key_map_a[key]
+        console.rule(f"{key} ({cls_a})")
+
+        if results[key] is None:
+            warn(f"Unable to handle item of type {cls_a}")
+            continue
+
+        checks, plots = results[key]
+
+        item = ComparisonItem(key=key, item_a=None, item_b=None, plots=config.plots)
+        item.checks = checks
+        item._generic_plots = plots
+        report_item_console(key, item.checks)
+
+        result.items.append(item)

--- a/src/histcmp/plot.py
+++ b/src/histcmp/plot.py
@@ -515,12 +515,6 @@ def plot_to_uri(figure, raster: bool = False):
     return datauri
 
 
-def init_render_worker():
-    import matplotlib
-
-    matplotlib.use("Agg", force=True)
-
-
 def render_plots(specs, key, label_a, label_b, plot_dir, format: str):
     """
     Render the plot specs produced by ComparisonItem.plot_specs and return the

--- a/src/histcmp/report.py
+++ b/src/histcmp/report.py
@@ -1,10 +1,8 @@
-from collections import deque
 from datetime import datetime
 from pathlib import Path
 import shutil
 from typing import Union, Optional
 import contextlib
-from concurrent.futures import ProcessPoolExecutor
 import re
 from rich.progress import track
 from rich.emoji import Emoji
@@ -14,7 +12,6 @@ import jinja2
 from histcmp.compare import Comparison
 from histcmp.checks import Status
 from histcmp.console import console
-from histcmp.plot import init_render_worker, render_plots
 from histcmp.root_helpers import push_root_level
 from histcmp import icons
 
@@ -145,7 +142,6 @@ def make_report(
     output: Path,
     plot_dir: Optional[Path] = None,
     format: str = "pdf",
-    jobs: int = 1,
 ):
     output.parent.mkdir(exist_ok=True, parents=True)
     if plot_dir is not None:
@@ -157,54 +153,17 @@ def make_report(
 
     import ROOT
 
-    if jobs == 1:
-        with push_root_level(ROOT.kWarning):
-            for item in track(
-                comparison.items, description="Making plots", console=console
-            ):
-                item.ensure_plots(
-                    output,
-                    plot_dir,
-                    comparison.label_monitored,
-                    comparison.label_reference,
-                    format=format,
-                )
-    else:
-        # The ROOT objects held by the comparison items cannot be pickled, so
-        # each item is converted to plain histograms just before its rendering
-        # is dispatched to the worker processes. Keeping only a bounded number
-        # of futures outstanding caps memory at O(jobs) in-flight items while
-        # the conversion overlaps with the rendering in the workers.
-        queue = deque()
-
-        def drain(limit: int):
-            while len(queue) > limit:
-                future, item = queue.popleft()
-                item._generic_plots = future.result()
-
-        with ProcessPoolExecutor(
-            max_workers=jobs, initializer=init_render_worker
-        ) as executor:
-            with push_root_level(ROOT.kWarning):
-                for item in track(
-                    comparison.items, description="Making plots", console=console
-                ):
-                    queue.append(
-                        (
-                            executor.submit(
-                                render_plots,
-                                item.plot_specs(),
-                                item.key,
-                                comparison.label_monitored,
-                                comparison.label_reference,
-                                plot_dir,
-                                format,
-                            ),
-                            item,
-                        )
-                    )
-                    drain(4 * jobs)
-            drain(0)
+    with push_root_level(ROOT.kWarning):
+        for item in track(
+            comparison.items, description="Making plots", console=console
+        ):
+            item.ensure_plots(
+                output,
+                plot_dir,
+                comparison.label_monitored,
+                comparison.label_reference,
+                format=format,
+            )
 
     with output.open("w") as fh:
         fh.write(env.get_template("main.html.j2").render(comparison=comparison))

--- a/src/histcmp/worker.py
+++ b/src/histcmp/worker.py
@@ -1,0 +1,78 @@
+"""
+Worker process side of the parallel comparison: each worker opens the two
+ROOT files once, then processes items scheduled by name — reading the
+objects, running the configured checks and rendering the plots. ROOT objects
+cannot be pickled, so only key strings and paths go in; the returned checks
+turn into their picklable CheckSummary on the way back (CompatCheck.__reduce__).
+The per-run constants (config, labels, plot directory, format) are shipped
+once via the pool initializer instead of with every item.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+_rf_a = None
+_rf_b = None
+_config = None
+_label_a = None
+_label_b = None
+_plot_dir = None
+_format = None
+
+
+def init_worker(
+    file_a: str,
+    file_b: str,
+    config,
+    label_a: str,
+    label_b: str,
+    plot_dir: Optional[Path],
+    format: str,
+):
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+
+    import ROOT
+
+    ROOT.gROOT.SetBatch(True)
+    ROOT.gErrorIgnoreLevel = ROOT.kWarning
+
+    global _rf_a, _rf_b, _config, _label_a, _label_b, _plot_dir, _format
+    _rf_a = ROOT.TFile.Open(file_a)
+    _rf_b = ROOT.TFile.Open(file_b)
+    _config = config
+    _label_a = label_a
+    _label_b = label_b
+    _plot_dir = plot_dir
+    _format = format
+
+
+def _read(rf, path: str):
+    obj = rf.Get(path)
+    if hasattr(obj, "SetDirectory"):
+        obj.SetDirectory(0)
+    return obj
+
+
+def process_item(key: str, path_a: str, path_b: str):
+    from histcmp.compare import build_checks, build_plot_specs, can_handle_item
+    from histcmp.plot import render_plots
+
+    item_a = _read(_rf_a, path_a)
+    item_b = _read(_rf_b, path_b)
+
+    if not can_handle_item(item_a):
+        return None
+
+    checks = build_checks(_config.checks, key, item_a, item_b)
+    plots = render_plots(
+        build_plot_specs(item_a, item_b, _config.plots),
+        key,
+        _label_a,
+        _label_b,
+        _plot_dir,
+        _format,
+    )
+
+    return checks, plots


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Stacked on #7** — the branch contains #7's two commits plus one commit on top ([`49ec3f2`](https://github.com/andiwand/histcmp/commit/49ec3f2)); review that last commit for the delta. #7 parallelizes only the matplotlib rendering; profiling a physmon `performance_trackfitting.root` self-comparison (234 items, 394 figures) shows the serial remainder is dominated by the checks (~20 s of ROOT compute — Chi2/Kolmogorov/etc. across 2130 check instances) and the ROOT→numpy conversion (~10 s), while the actual file I/O is negligible (~0.2 s). So this PR parallelizes the whole per-item pipeline instead, and replaces #7's rendering pool with it.

### Design

With `--jobs/-j N` (default 1 = unchanged serial path), the common items are scheduled **by name** onto `N` worker processes. Each worker opens the two ROOT files once in its initializer, reads the objects itself, runs the configured checks, and renders the plots. ROOT objects cannot be pickled (attempting it crashes ROOT), so only key strings/paths go in — and on the way back, `CompatCheck.__reduce__` turns each check into a picklable `CheckSummary` at the process boundary. The summaries expose the same attributes as the checks (`status`, `label`, `is_applicable`, …), so the console output, GitHub Actions markers, report template and status aggregation code are shared between the serial and parallel paths.

- `collect_items` gains a lazy mode reading only key/class names and directories, giving workers `TFile.Get`-able paths.
- Check construction and per-item console reporting move out of `compare()` into `build_checks()` / `report_item_console()`, used by both paths.
- `make_report` drops its rendering pool again: with `-j` the plots come back from the workers already rendered, and `ensure_plots` skips those items.

A chunk of the diff churn is moves, not new code — `build_checks` and `report_item_console` are the old `compare()` loop body relocated so both paths share it.

### Measurements

Same machine and input as the #7 numbers, wall clock:

| | -j 1 | -j 2 | -j 4 | -j 8 |
|---|---|---|---|---|
| #7 (render-only pool) | 68 s | 55 s | 46 s | 44 s |
| this PR (full pipeline) | 70 s | 40 s | 24 s | 19 s |

#7 plateaus at the ~30 s serial floor (checks + conversion); this PR scales until process startup and the report write dominate. Total CPU time is the same for both (~80 s), so on a CI runner already saturated by parallel histcmp invocations the two behave alike — the win here is per-invocation latency.

### Test

Reports, plot files (394), per-check tag counts, GitHub Actions `::error` markers and exit codes are identical to the serial path, validated on both a passing self-comparison and a failing KF-vs-GSF comparison (138 failed items, exit 1). `tests/`: 1 passed, 1 pre-existing failure (`test_comparison_ckf_main`, typer/click exit-code handling) that fails identically on `main`.

Side note found while wiring `__reduce__`: `ResidualCheck.is_applicable` is missing its `@property` decorator, so everywhere on `main` it evaluates as a truthy bound method (i.e. the check is always treated as applicable). This PR deliberately preserves that behavior (`bool(self.is_applicable)`); fixing the decorator would change report outcomes and should be its own PR.